### PR TITLE
chore: use correct deploy trigger

### DIFF
--- a/tools/minishift-build/rest.sh
+++ b/tools/minishift-build/rest.sh
@@ -3,5 +3,5 @@
 . $(dirname `realpath $0`)/vars.sh
 
 prepare_dir syndesis-rest
-./mvnw clean install -Pflash,deploy -Dfabric8.mode=kubernetes
+./mvnw clean install -Ddeploy -Dfabric8.mode=kubernetes
 oc delete pod $(pod rest)


### PR DESCRIPTION
The `deploy` is a Maven property that activates two Maven profiles
`flash` and `deploy` so this can be simpler.