### PR TITLE
chore: fix the pod call in ui.sh

### DIFF
--- a/tools/minishift-build/ui.sh
+++ b/tools/minishift-build/ui.sh
@@ -6,4 +6,4 @@ prepare_dir syndesis-ui
 yarn install
 yarn ng build -- --aot --prod
 docker build -t syndesis/syndesis-ui -f docker/Dockerfile .
-oc delete pod $(pod syndesis-ui)
+oc delete pod $(pod ui)


### PR DESCRIPTION
The `ui.sh` specifies `syndesis-ui` to the pod function call, that
expands to `syndesis-syndesis-ui`, this chages the argument to just
`ui`.