### PR TITLE
feat: Add migrate images script to migrate images between two docker registries on openshift

### DIFF
--- a/tools/images/migrate-images.sh
+++ b/tools/images/migrate-images.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+FROM_REGISTRY_PREFIX=${1:-docker-registry.engineering.redhat.com/jboss-fuse-7-tech-preview}
+TO_REGISTRY_PREFIX=${2:-registry.fuse-ignite.openshift.com/jboss-fuse-7-tech-preview}
+VERSION=${3:-1.0}
+IMAGES=${4:-"fuse-ignite-java-openshift fuse-ignite-karaf-openshift fuse-ignite-mapper fuse-ignite-mapper fuse-ignite-rest fuse-ignite-token-rp fuse-ignite-ui fuse-ignite-verifier"}
+
+for image in ${IMAGES}; do
+  docker pull ${FROM_REGISTRY_PREFIX}/${image}:${VERSION}
+  docker tag ${FROM_REGISTRY_PREFIX}/${image}:${VERSION} ${TO_REGISTRY_PREFIX}/${image}:${VERSION}
+  docker push ${TO_REGISTRY_PREFIX}/${image}:${VERSION}
+done


### PR DESCRIPTION
Note that this requires being logged in to both registries via `docker login` before this script is
run.

/cc @rhuss