### PR TITLE
fix: adapt to Atlasmap aggregated repository

### DIFF
--- a/tools/minishift-build/atlasmap.sh
+++ b/tools/minishift-build/atlasmap.sh
@@ -3,6 +3,7 @@
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/vars.sh"
 
 prepare_dir atlasmap
+cd runtime
 ./mvnw clean install -DskipTests
 cd runtime
 ../mvnw clean package fabric8:build -Dfabric8.mode=kubernetes -DskipTests


### PR DESCRIPTION
Atlasmap git repository is now aggregated repository containing all
other repositories as git submodules, due to that some paths have
changed this updates the script to reflect that.