### PR TITLE
fix: script path resolution

### DIFF
--- a/tools/minishift-build/atlasmap.sh
+++ b/tools/minishift-build/atlasmap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(cd "$(dirname "$(readlink -f "$0")")" && pwd)/vars.sh"
+. "$(cd "$(dirname "$(readlink -f "$BASH_SOURCE")")" && pwd)/vars.sh"
 
 prepare_dir atlasmap
 cd runtime

--- a/tools/minishift-build/build-all.sh
+++ b/tools/minishift-build/build-all.sh
@@ -5,7 +5,7 @@ set -e
 eval $(minishift docker-env)
 oc config use-context minishift
 oc login -u developer -p developer
-d="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+d="$(cd "$(dirname "$(readlink -f "$BASH_SOURCE")")" && pwd)"
 . $d/integration-runtime.sh
 . $d/rest.sh
 . $d/atlasmap.sh

--- a/tools/minishift-build/integration-runtime.sh
+++ b/tools/minishift-build/integration-runtime.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(cd "$(dirname "$(readlink -f "$0")")" && pwd)/vars.sh"
+. "$(cd "$(dirname "$(readlink -f "$BASH_SOURCE")")" && pwd)/vars.sh"
 
 prepare_dir syndesis-integration-runtime
 ./mvnw clean install -DskipTests

--- a/tools/minishift-build/rest.sh
+++ b/tools/minishift-build/rest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(cd "$(dirname "$(readlink -f "$0")")" && pwd)/vars.sh"
+. "$(cd "$(dirname "$(readlink -f "$BASH_SOURCE")")" && pwd)/vars.sh"
 
 prepare_dir syndesis-rest
 ./mvnw clean install -Ddeploy

--- a/tools/minishift-build/ui.sh
+++ b/tools/minishift-build/ui.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(cd "$(dirname "$(readlink -f "$0")")" && pwd)/vars.sh"
+. "$(cd "$(dirname "$(readlink -f "$BASH_SOURCE")")" && pwd)/vars.sh"
 
 prepare_dir syndesis-ui
 yarn install

--- a/tools/minishift-build/vars.sh
+++ b/tools/minishift-build/vars.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-root_dir_file="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)/root_dir"
+root_dir_file="$(cd "$(dirname "$(readlink -f "$BASH_SOURCE")")" && pwd)/root_dir"
 if [ -f  $root_dir_file ]; then
   root=$(cat $root_dir_file)  
 else 
   # Common includes
-  pushd `dirname $0`/.. > /dev/null
-  root=`pwd`
+  pushd "$(cd "$(dirname "$(readlink -f "$BASH_SOURCE")")" && pwd)/.." > /dev/null
+  root=$(pwd)
   popd > /dev/null
 fi
 

--- a/tools/minishift-build/verifier.sh
+++ b/tools/minishift-build/verifier.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "$(cd "$(dirname "$(readlink -f "$0")")" && pwd)/vars.sh"
+. "$(cd "$(dirname "$(readlink -f "$BASH_SOURCE")")" && pwd)/vars.sh"
 
 prepare_dir syndesis-verifier
 ./mvnw clean install fabric8:build -Dfabric8.mode=kubernetes -PskipTests


### PR DESCRIPTION
Scripts worked when invoked individually but not when invoked via
`build-all.sh` script. This I've tested with `./build-all.sh` individual
scripts and symlinked `build-all.sh` and individual scripts, so it
should be much better.